### PR TITLE
make the plugin to be a no-op when running in dependabot env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ const plugin: Plugin<NpmHooks> = {
       if (!registry.includes('npm.pkg.dev/')) {
         return null;
       }
+
+      if (process.env.DEPENDABOT) {
+        console.warn('Dependabot detected, skipping GCP authentication');
+        return currentHeader;
+      }
+
       const cache = configuration.get('gcpAccessToken');
       let token: string = cache.get('token');
       if (!token || cache.get('expiresAt') < Date.now() + 1000) {


### PR DESCRIPTION
Make the plugin to no-op when running in dependabot, assuming there is such an env variable (as described in https://github.com/dependabot/dependabot-core#dependabot-on-ci)